### PR TITLE
Avoid too many changes detected

### DIFF
--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-default-members = ["project"]
+default-members = ["my-project"]
 members = [
     "my-project",
     "xtask",

--- a/examples/demo/xtask/src/main.rs
+++ b/examples/demo/xtask/src/main.rs
@@ -1,16 +1,16 @@
 use std::process::Command;
 use xtask_watch::{
-    anyhow::{ensure, Context, Result},
     clap,
+    clap::Parser,
 };
 
-#[derive(clap::Parser)]
+#[derive(Parser)]
 enum Opt {
     Watch(xtask_watch::Watch),
 }
 
-fn main() -> Result<()> {
-    let opt: Opt = clap::Parser::parse();
+fn main() {
+    let opt: Opt = Parser::parse();
 
     env_logger::builder()
         .filter(Some("xtask"), log::LevelFilter::Trace)
@@ -22,9 +22,7 @@ fn main() -> Result<()> {
     match opt {
         Opt::Watch(watch) => {
             log::info!("starting to watch `project`");
-            watch.run(run_command)?;
+            watch.run(run_command).expect("cannot run watch");
         }
     }
-
-    Ok(())
 }

--- a/examples/demo/xtask/src/main.rs
+++ b/examples/demo/xtask/src/main.rs
@@ -13,7 +13,8 @@ fn main() -> Result<()> {
     let opt: Opt = clap::Parser::parse();
 
     env_logger::builder()
-        .filter(Some("xtask"), log::LevelFilter::Trace)
+    .filter_level(log::LevelFilter::Info)
+        .parse_default_env()
         .init();
 
     let mut run_command = Command::new("cargo");

--- a/examples/demo/xtask/src/main.rs
+++ b/examples/demo/xtask/src/main.rs
@@ -1,16 +1,16 @@
 use std::process::Command;
 use xtask_watch::{
+    anyhow::Result,
     clap,
-    clap::Parser,
 };
 
-#[derive(Parser)]
+#[derive(clap::Parser)]
 enum Opt {
     Watch(xtask_watch::Watch),
 }
 
-fn main() {
-    let opt: Opt = Parser::parse();
+fn main() -> Result<()> {
+    let opt: Opt = clap::Parser::parse();
 
     env_logger::builder()
         .filter(Some("xtask"), log::LevelFilter::Trace)
@@ -22,7 +22,9 @@ fn main() {
     match opt {
         Opt::Watch(watch) => {
             log::info!("starting to watch `project`");
-            watch.run(run_command).expect("cannot run watch");
+            watch.run(run_command)?;
         }
     }
+
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,9 +229,7 @@ impl Watch {
                     child = command.spawn().context("cannot spawn command")?;
                     command_start = Instant::now();
                 }
-                Ok(event) => {
-                    log::trace!("Ignoring changes in {:?}", event);
-                }
+                Ok(event) => log::trace!("Ignoring changes in {:?}", event),
                 Err(err) => log::error!("watch error: {}", err),
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,9 @@ impl Watch {
                     child = command.spawn().context("cannot spawn command")?;
                     command_start = Instant::now();
                 }
-                Ok(_) => {}
+                Ok(event) => {
+                    log::trace!("Ignoring changes in {:?}", event);
+                }
                 Err(err) => log::error!("watch error: {}", err),
             }
         }


### PR DESCRIPTION
Avoid to trigger the watch when a change in a temp file is detected or when a file is created without being written