### PR TITLE
Also exclude file renaming

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,7 +369,7 @@ impl Watch {
         self.watch_paths.iter().any(|x| {
             path.strip_prefix(x)
                 .iter()
-                .any(|x| x.to_string_lossy().starts_with('~'))
+                .any(|x| x.to_string_lossy().ends_with('~'))
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,6 +297,7 @@ impl Watch {
                     && !self.is_hidden_path(&path)
                     && !self.is_backup_file(&path)
                     && op != notify::Op::CREATE
+                    && op != notify::Op::RENAME
                     && command_start.elapsed() >= self.debounce =>
                 {
                     log::trace!("Detected changes at {} | {:?}", path.display(), op);


### PR DESCRIPTION
Editors do weird things with their backup files. Only the changes on files really matter.

```
[2022-02-14T09:51:10Z TRACE xtask_watch] Detected changes at /home/cecile/repos/ta-smart-api/xtask/src/api.rs | RENAME
```

Note that the following one is a backup file and it should have been ignored by `is_backup_file`.

```
[2022-02-14T09:53:45Z TRACE xtask_watch] Detected changes at /home/cecile/repos/ta-smart-api/src/sv.rs~ | RENAME
```