### PR TITLE
Update demo example with latest changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - uses: Swatinem/rust-cache@v1
+
       - name: cargo check
         run: cargo check
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,8 +31,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v1
-
       - name: cargo check
         run: cargo check
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
           - 1.78.0 # MSRV
         include:
           - os: ubuntu-latest
-            rust: stable
+            rust: 1.78.0
             lint: 1
     runs-on: ${{ matrix.os }}
     steps:
@@ -30,8 +30,6 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v1
 
       - name: cargo check
         run: cargo check

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,7 @@ pub struct Watch {
     /// Cargo command(s) to execute on changes.
     ///
     /// The default is `[ check ]`
-    #[clap(long = "exec", short = 'x', default_values = ["check"])]
+    #[clap(long = "exec", short = 'x')]
     pub cargo_commands: Vec<String>,
     /// Watch specific file(s) or folder(s).
     ///


### PR DESCRIPTION
@yozhgoor  The previous release will need to be yanked because there is no way for the user of this lib to remove that default_value. It will force a cargo check on everybody it's unusable.

Related to #28
