### PR TITLE
feat: add --commit flag to restart command when git HEAD changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `--commit` flag to also restart the command when git HEAD changes. (#36)
-
-### Changed
-
-- Commit-change detection now considers only valid event paths (existing, non-excluded,
-  non-hidden, non-backup files), ignoring stale or deleted paths that could previously
-  cause a `ChangeDetected` event to be emitted instead. (#36)
+- `--commit` flag to restart the command when git HEAD changes. (#36)
 
 ### Fixed
 
-- When `--commit` is used alongside a watch path that is a parent of `.git`,
-  git directory changes were incorrectly filtered out by the hidden-path check.
-  `is_hidden_path` now allows paths under explicitly-watched hidden directories. (#36)
+- `is_hidden_path` no longer filters out paths under explicitly-watched hidden
+  directories, fixing an issue where `--commit` could not detect git changes when
+  the watch path was a parent of `.git`. (#36)
+
+- Commit-change detection now ignores stale or deleted paths that could previously
+  trigger a spurious `ChangeDetected` event. (#36)
 
 ## [0.3.5] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `--commit` flag to also restart the command when git HEAD changes. (#36)
+
 ## [0.3.4] - 2026-05-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   directories, fixing an issue where `--commit` could not detect git changes when
   the watch path was a parent of `.git`. (#36)
 
-- Commit-change detection now ignores stale or deleted paths that could previously
-  trigger a spurious `ChangeDetected` event. (#36)
-
 ## [0.3.5] - 2026-06-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-hidden, non-backup files), ignoring stale or deleted paths that could previously
   cause a `ChangeDetected` event to be emitted instead. (#36)
 
+### Fixed
+
+- When `--commit` is used alongside a watch path that is a parent of `.git`,
+  git directory changes were incorrectly filtered out by the hidden-path check.
+  `is_hidden_path` now allows paths under explicitly-watched hidden directories. (#36)
+
 ## [0.3.5] - 2026-06-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `--commit` flag to also restart the command when git HEAD changes. (#36)
 
+### Changed
+
+- Commit-change detection now considers only valid event paths (existing, non-excluded,
+  non-hidden, non-backup files), ignoring stale or deleted paths that could previously
+  cause a `ChangeDetected` event to be emitted instead. (#36)
+
 ## [0.3.5] - 2026-06-02
 
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,6 +475,18 @@ impl Watch {
     }
 
     fn is_hidden_path(&self, path: &Path) -> bool {
+        // If the path is under a watch path whose last component starts
+        // with '.', the user explicitly opted into watching it — don't
+        // treat it as hidden (e.g. --commit adds .git/ to watch_paths).
+        if self.watch_paths.iter().any(|x| {
+            x.file_name()
+                .and_then(|s| s.to_str())
+                .is_some_and(|s| s.starts_with('.'))
+                && path.starts_with(x)
+        }) {
+            return false;
+        }
+
         self.watch_paths.iter().any(|x| {
             path.strip_prefix(x)
                 .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,55 @@ pub fn xtask_command() -> Command {
     Command::new(env::args_os().next().unwrap())
 }
 
+/// Resolve the actual git directory path via `git rev-parse --git-dir`.
+///
+/// Git handles regular repos, worktrees, and submodules transparently.
+fn resolve_git_dir(repo_root: &Path) -> Result<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .current_dir(repo_root)
+        .output()
+        .context("failed to run `git rev-parse --git-dir`")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("not a git repository: {stderr}");
+    }
+
+    let dir = String::from_utf8(output.stdout).context("git output is not valid UTF-8")?;
+    let dir = dir.trim();
+
+    let path = if Path::new(dir).is_absolute() {
+        PathBuf::from(dir)
+    } else {
+        repo_root.join(dir)
+    };
+
+    path.canonicalize()
+        .with_context(|| format!("canonicalize git dir `{dir}`"))
+}
+
+/// Get the current HEAD commit hash via `git rev-parse HEAD`.
+fn get_current_head() -> Result<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(metadata().workspace_root.as_std_path())
+        .output()
+        .context("failed to run `git rev-parse HEAD`")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git rev-parse HEAD failed: {stderr}");
+    }
+
+    let hash = String::from_utf8(output.stdout)
+        .context("git output is not valid UTF-8")?
+        .trim()
+        .to_string();
+
+    Ok(hash)
+}
+
 /// Watches over your project's source code, relaunching a given command when
 /// changes are detected.
 ///
@@ -71,6 +120,14 @@ pub struct Watch {
     /// Paths or glob patterns, relative to the workspace root, that will be excluded.
     #[clap(skip)]
     pub workspace_exclude_paths: Vec<PathBuf>,
+    /// Watch for commit changes in addition to file changes.
+    ///
+    /// Monitors the git directory (resolved via `git rev-parse --git-dir`)
+    /// for when the current git commit (HEAD) changes.
+    /// For worktrees, the watched directory is the git directory resolved
+    /// via `git rev-parse --git-dir`, not the workspace-local `.git` file.
+    #[clap(long = "commit")]
+    pub commit: bool,
     /// Throttle events to prevent the command to be re-executed too early
     /// right after an execution already occurred.
     ///
@@ -153,6 +210,12 @@ impl Watch {
         self.watch_lock.clone()
     }
 
+    /// Enable commit mode: also restart the command when the git HEAD changes.
+    pub fn commit(mut self) -> Self {
+        self.commit = true;
+        self
+    }
+
     /// Set the debounce duration after relaunching the command.
     pub fn debounce(mut self, duration: Duration) -> Self {
         self.debounce = duration;
@@ -194,6 +257,15 @@ impl Watch {
 
         self.prepare_excludes()?;
 
+        let git_dirs: Vec<PathBuf> = if self.commit {
+            let git_dir = resolve_git_dir(metadata.workspace_root.as_std_path())
+                .context("--commit requires a git repository")?;
+            self.watch_paths.push(git_dir.clone());
+            vec![git_dir]
+        } else {
+            Vec::new()
+        };
+
         if self.watch_paths.is_empty() {
             self.watch_paths
                 .push(metadata.workspace_root.clone().into_std_path_buf());
@@ -210,10 +282,24 @@ impl Watch {
 
         let (tx, rx) = mpsc::channel();
 
+        let current_commit = if self.commit {
+            match get_current_head() {
+                Ok(hash) => Some(hash),
+                Err(err) => {
+                    log::warn!("failed to read initial git HEAD: {err:?}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         let handler = WatchEventHandler {
             watch: self.clone(),
             tx: tx.clone(),
             command_start: Instant::now(),
+            current_commit,
+            git_dirs,
         };
 
         let mut watcher =
@@ -407,31 +493,69 @@ struct WatchEventHandler {
     watch: Watch,
     tx: mpsc::Sender<Event>,
     command_start: Instant,
+    current_commit: Option<String>,
+    git_dirs: Vec<PathBuf>,
 }
 
 impl notify::EventHandler for WatchEventHandler {
     fn handle_event(&mut self, event: Result<notify::Event, notify::Error>) {
-        match event {
-            Ok(event) => {
-                if (event.kind.is_modify() || event.kind.is_create())
-                    && event.paths.iter().any(|x| {
-                        !self.watch.is_excluded_path(x)
-                            && x.exists()
-                            && !self.watch.is_hidden_path(x)
-                            && !self.watch.is_backup_file(x)
-                            && self.command_start.elapsed() >= self.watch.debounce
-                    })
-                {
-                    log::trace!("Changes detected in {event:?}");
-                    self.command_start = Instant::now();
-
-                    self.tx.send(Event::ChangeDetected).expect("can send");
-                } else {
-                    log::trace!("Ignoring changes in {event:?}");
-                }
+        let event = match event {
+            Ok(event) => event,
+            Err(err) => {
+                log::error!("watch error: {err}");
+                return;
             }
-            Err(err) => log::error!("watch error: {err}"),
+        };
+
+        if self.command_start.elapsed() < self.watch.debounce {
+            log::trace!("Ignoring changes (debounce): {event:?}");
+            return;
         }
+
+        let valid: Vec<_> = event
+            .paths
+            .iter()
+            .filter(|x| {
+                (event.kind.is_modify() || event.kind.is_create())
+                    && !self.watch.is_excluded_path(x)
+                    && x.exists()
+                    && !self.watch.is_hidden_path(x)
+                    && !self.watch.is_backup_file(x)
+            })
+            .collect();
+
+        if valid.is_empty() {
+            log::trace!("Ignoring changes in {event:?}");
+            return;
+        }
+
+        if self.watch.commit {
+            let all_under_git = valid
+                .iter()
+                .all(|p| self.git_dirs.iter().any(|g| p.starts_with(g)));
+
+            if all_under_git {
+                match get_current_head() {
+                    Ok(hash) if Some(hash.as_str()) != self.current_commit.as_deref() => {
+                        log::trace!("HEAD changed: {:?} -> {hash}", self.current_commit);
+                        self.current_commit = Some(hash);
+                        self.command_start = Instant::now();
+                        self.tx.send(Event::ChangeDetected).expect("can send");
+                    }
+                    Ok(_) => {
+                        log::trace!("HEAD unchanged, ignoring event");
+                    }
+                    Err(err) => {
+                        log::error!("failed to read git HEAD: {err}");
+                    }
+                }
+                return;
+            }
+        }
+
+        log::trace!("Changes detected in {event:?}");
+        self.command_start = Instant::now();
+        self.tx.send(Event::ChangeDetected).expect("can send");
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,8 +269,7 @@ impl Watch {
         self.prepare_excludes()?;
 
         let git_dirs: Vec<PathBuf> = if self.commit {
-            let git_dir = resolve_git_dir()
-                .context("--commit requires a git repository")?;
+            let git_dir = resolve_git_dir().context("--commit requires a git repository")?;
             self.watch_paths.push(git_dir.clone());
             vec![git_dir]
         } else {
@@ -400,7 +399,10 @@ impl Watch {
                                 if let Some(current_hash) = &current_commit {
                                     match get_current_head() {
                                         Ok(hash) if &hash != current_hash => {
-                                            log::trace!("HEAD changed: {:?} -> {hash}", current_commit);
+                                            log::trace!(
+                                                "HEAD changed: {:?} -> {hash}",
+                                                current_commit
+                                            );
                                             current_commit = Some(hash);
                                         }
                                         Ok(_) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -534,18 +534,27 @@ impl notify::EventHandler for WatchEventHandler {
     fn handle_event(&mut self, event: Result<notify::Event, notify::Error>) {
         match event {
             Ok(event) => {
-                if (event.kind.is_modify() || event.kind.is_create())
-                    && event.paths.iter().any(|x| {
-                        !self.watch.is_excluded_path(x)
-                            && x.exists()
-                            && !self.watch.is_hidden_path(x)
-                            && !self.watch.is_backup_file(x)
-                    })
-                {
-                    if event
+                if event.kind.is_modify() || event.kind.is_create() {
+                    let valids = event
                         .paths
                         .iter()
-                        .all(|p| self.git_dirs.iter().any(|g| p.starts_with(g)))
+                        .filter(|x| {
+                            x.exists()
+                                && !self.watch.is_excluded_path(x)
+                                && !self.watch.is_hidden_path(x)
+                                && !self.watch.is_backup_file(x)
+                        })
+                        .collect::<Vec<_>>();
+
+                    if valids.is_empty() {
+                        log::trace!("Ignoring changes in {event:?}");
+                        return;
+                    }
+
+                    if self.watch.commit
+                        && valids
+                            .iter()
+                            .all(|p| self.git_dirs.iter().any(|g| p.starts_with(g)))
                     {
                         match get_current_head() {
                             Ok(hash) if Some(hash.as_str()) != self.current_commit.as_deref() => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,23 +371,13 @@ impl Watch {
             // been quiet for `debounce`.
             loop {
                 match rx.recv_timeout(self.debounce) {
-                    Ok(Event::ChangeDetected) => {
-                        log::trace!("Change detected, resetting debounce timer");
-                        has_file_changes = true;
-                        if !pending_build {
-                            // Cancel any in-progress build immediately so we
-                            // build the latest version, not an intermediate one.
-                            current_child.terminate();
-                            generation += 1;
-                            if lock_guard.is_none() {
-                                lock_guard = Some(self.watch_lock.write());
-                            }
-                            pending_build = true;
+                    Ok(Event::ChangeDetected { git }) => {
+                        if git {
+                            log::trace!("Git directory change detected, resetting debounce timer");
+                        } else {
+                            log::trace!("Change detected, resetting debounce timer");
+                            has_file_changes = true;
                         }
-                        // Loop back to reset the recv_timeout.
-                    }
-                    Ok(Event::GitDirChangeDetected) => {
-                        log::trace!("Git directory change detected, resetting debounce timer");
                         if !pending_build {
                             current_child.terminate();
                             generation += 1;
@@ -601,12 +591,16 @@ impl notify::EventHandler for WatchEventHandler {
                         && valid_paths.all(|p| self.git_dirs.iter().any(|g| p.starts_with(g)))
                     {
                         log::trace!("Git directory change detected in {event:?}");
-                        self.tx.send(Event::GitDirChangeDetected).expect("can send");
+                        self.tx
+                            .send(Event::ChangeDetected { git: true })
+                            .expect("can send");
                         return;
                     }
 
                     log::trace!("Changes detected in {event:?}");
-                    self.tx.send(Event::ChangeDetected).expect("can send");
+                    self.tx
+                        .send(Event::ChangeDetected { git: false })
+                        .expect("can send");
                 } else {
                     log::trace!("Ignoring non-create/modify event: {event:?}");
                 }
@@ -808,8 +802,7 @@ impl WatchLock {
 #[derive(Debug)]
 enum Event {
     CommandSucceeded(u64),
-    ChangeDetected,
-    GitDirChangeDetected,
+    ChangeDetected { git: bool },
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,22 +292,9 @@ impl Watch {
 
         let (tx, rx) = mpsc::channel();
 
-        let current_commit = if self.commit {
-            match get_current_head() {
-                Ok(hash) => Some(hash),
-                Err(err) => {
-                    log::warn!("failed to read initial git HEAD: {err:?}");
-                    None
-                }
-            }
-        } else {
-            None
-        };
-
         let handler = WatchEventHandler {
             watch: self.clone(),
             tx: tx.clone(),
-            current_commit,
             git_dirs,
         };
 
@@ -329,10 +316,23 @@ impl Watch {
         // been translated into a spawned command.  It starts as `true` so the
         // first build fires immediately without waiting for a file-change event.
         let mut pending_build = true;
+        let mut current_commit = if self.commit {
+            match get_current_head() {
+                Ok(hash) => Some(hash),
+                Err(err) => {
+                    log::warn!("failed to read initial git HEAD: {err:?}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        let mut has_file_changes = false;
 
         loop {
             if pending_build {
                 pending_build = false;
+                has_file_changes = false;
                 log::info!("Running command");
                 let mut current_child = current_child.clone();
                 let mut list = list.clone();
@@ -373,6 +373,7 @@ impl Watch {
                 match rx.recv_timeout(self.debounce) {
                     Ok(Event::ChangeDetected) => {
                         log::trace!("Change detected, resetting debounce timer");
+                        has_file_changes = true;
                         if !pending_build {
                             // Cancel any in-progress build immediately so we
                             // build the latest version, not an intermediate one.
@@ -384,6 +385,17 @@ impl Watch {
                             pending_build = true;
                         }
                         // Loop back to reset the recv_timeout.
+                    }
+                    Ok(Event::GitDirChangeDetected) => {
+                        log::trace!("Git directory change detected, resetting debounce timer");
+                        if !pending_build {
+                            current_child.terminate();
+                            generation += 1;
+                            if lock_guard.is_none() {
+                                lock_guard = Some(self.watch_lock.write());
+                            }
+                            pending_build = true;
+                        }
                     }
                     Ok(Event::CommandSucceeded(build_id)) if build_id == generation => {
                         log::trace!("Command succeeded, releasing lock");
@@ -399,6 +411,27 @@ impl Watch {
                         // Quiet for `debounce` — time to build if there is a
                         // pending change.
                         if pending_build {
+                            // Only check HEAD if commit mode and no real file changes.
+                            if self.commit && !has_file_changes {
+                                match get_current_head() {
+                                    Ok(hash)
+                                        if Some(hash.as_str()) != current_commit.as_deref() =>
+                                    {
+                                        log::trace!("HEAD changed: {:?} -> {hash}", current_commit);
+                                        current_commit = Some(hash);
+                                    }
+                                    Ok(_) => {
+                                        log::trace!("HEAD unchanged, skipping build");
+                                        pending_build = false;
+                                        continue;
+                                    }
+                                    Err(err) => {
+                                        log::error!("failed to read git HEAD: {err}");
+                                        pending_build = false;
+                                        continue;
+                                    }
+                                }
+                            }
                             break;
                         }
                     }
@@ -533,7 +566,6 @@ impl Watch {
 struct WatchEventHandler {
     watch: Watch,
     tx: mpsc::Sender<Event>,
-    current_commit: Option<String>,
     git_dirs: Vec<PathBuf>,
 }
 
@@ -556,20 +588,9 @@ impl notify::EventHandler for WatchEventHandler {
                     if self.watch.commit
                         && valid_paths.all(|p| self.git_dirs.iter().any(|g| p.starts_with(g)))
                     {
-                        match get_current_head() {
-                            Ok(hash) if Some(hash.as_str()) != self.current_commit.as_deref() => {
-                                log::trace!("HEAD changed: {:?} -> {hash}", self.current_commit);
-                                self.current_commit = Some(hash);
-                            }
-                            Ok(_) => {
-                                log::trace!("HEAD unchanged, ignoring event");
-                                return;
-                            }
-                            Err(err) => {
-                                log::error!("failed to read git HEAD: {err}");
-                                return;
-                            }
-                        }
+                        log::trace!("Git directory change detected in {event:?}");
+                        self.tx.send(Event::GitDirChangeDetected).expect("can send");
+                        return;
                     }
 
                     log::trace!("Changes detected in {event:?}");
@@ -776,6 +797,7 @@ impl WatchLock {
 enum Event {
     CommandSucceeded(u64),
     ChangeDetected,
+    GitDirChangeDetected,
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,16 +560,16 @@ impl notify::EventHandler for WatchEventHandler {
                             Ok(hash) if Some(hash.as_str()) != self.current_commit.as_deref() => {
                                 log::trace!("HEAD changed: {:?} -> {hash}", self.current_commit);
                                 self.current_commit = Some(hash);
-                                self.tx.send(Event::ChangeDetected).expect("can send");
                             }
                             Ok(_) => {
                                 log::trace!("HEAD unchanged, ignoring event");
+                                return;
                             }
                             Err(err) => {
                                 log::error!("failed to read git HEAD: {err}");
+                                return;
                             }
                         }
-                        return;
                     }
 
                     log::trace!("Changes detected in {event:?}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,13 +318,7 @@ impl Watch {
         // first build fires immediately without waiting for a file-change event.
         let mut pending_build = true;
         let mut current_commit = if self.commit {
-            match get_current_head() {
-                Ok(hash) => Some(hash),
-                Err(err) => {
-                    log::warn!("failed to read initial git HEAD: {err:?}");
-                    None
-                }
-            }
+            Some(get_current_head()?)
         } else {
             None
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,8 @@ pub fn xtask_command() -> Command {
 /// Resolve the actual git directory path via `git rev-parse --git-dir`.
 ///
 /// Git handles regular repos, worktrees, and submodules transparently.
-fn resolve_git_dir(repo_root: &Path) -> Result<PathBuf> {
+fn resolve_git_dir() -> Result<PathBuf> {
+    let repo_root = metadata().workspace_root.as_std_path();
     let output = Command::new("git")
         .args(["rev-parse", "--git-dir"])
         .current_dir(repo_root)
@@ -268,7 +269,7 @@ impl Watch {
         self.prepare_excludes()?;
 
         let git_dirs: Vec<PathBuf> = if self.commit {
-            let git_dir = resolve_git_dir(metadata.workspace_root.as_std_path())
+            let git_dir = resolve_git_dir()
                 .context("--commit requires a git repository")?;
             self.watch_paths.push(git_dir.clone());
             vec![git_dir]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -457,6 +457,13 @@ impl Watch {
         })
     }
 
+    fn is_valid_path(&self, path: &Path) -> bool {
+        path.exists()
+            && !self.is_excluded_path(path)
+            && !self.is_hidden_path(path)
+            && !self.is_backup_file(path)
+    }
+
     fn is_glob_pattern(path: &Path) -> bool {
         let s = path.as_os_str().to_string_lossy();
         s.contains('*') || s.contains('?') || (!cfg!(windows) && s.contains('['))
@@ -535,26 +542,19 @@ impl notify::EventHandler for WatchEventHandler {
         match event {
             Ok(event) => {
                 if event.kind.is_modify() || event.kind.is_create() {
-                    let valids = event
+                    let mut valid_paths = event
                         .paths
                         .iter()
-                        .filter(|x| {
-                            x.exists()
-                                && !self.watch.is_excluded_path(x)
-                                && !self.watch.is_hidden_path(x)
-                                && !self.watch.is_backup_file(x)
-                        })
-                        .collect::<Vec<_>>();
+                        .filter(|p| self.watch.is_valid_path(p))
+                        .peekable();
 
-                    if valids.is_empty() {
-                        log::trace!("Ignoring changes in {event:?}");
+                    if valid_paths.peek().is_none() {
+                        log::trace!("No valid paths in {event:?}, ignoring");
                         return;
                     }
 
                     if self.watch.commit
-                        && valids
-                            .iter()
-                            .all(|p| self.git_dirs.iter().any(|g| p.starts_with(g)))
+                        && valid_paths.all(|p| self.git_dirs.iter().any(|g| p.starts_with(g)))
                     {
                         match get_current_head() {
                             Ok(hash) if Some(hash.as_str()) != self.current_commit.as_deref() => {
@@ -575,7 +575,7 @@ impl notify::EventHandler for WatchEventHandler {
                     log::trace!("Changes detected in {event:?}");
                     self.tx.send(Event::ChangeDetected).expect("can send");
                 } else {
-                    log::trace!("Ignoring changes in {event:?}");
+                    log::trace!("Ignoring non-create/modify event: {event:?}");
                 }
             }
             Err(err) => log::error!("watch error: {err}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,24 +396,23 @@ impl Watch {
                         // Quiet for `debounce` — time to build if there is a
                         // pending change.
                         if pending_build {
-                            // Only check HEAD if commit mode and no real file changes.
-                            if self.commit && !has_file_changes {
-                                match get_current_head() {
-                                    Ok(hash)
-                                        if Some(hash.as_str()) != current_commit.as_deref() =>
-                                    {
-                                        log::trace!("HEAD changed: {:?} -> {hash}", current_commit);
-                                        current_commit = Some(hash);
-                                    }
-                                    Ok(_) => {
-                                        log::trace!("HEAD unchanged, skipping build");
-                                        pending_build = false;
-                                        continue;
-                                    }
-                                    Err(err) => {
-                                        log::error!("failed to read git HEAD: {err}");
-                                        pending_build = false;
-                                        continue;
+                            if !has_file_changes {
+                                if let Some(current_hash) = &current_commit {
+                                    match get_current_head() {
+                                        Ok(hash) if &hash != current_hash => {
+                                            log::trace!("HEAD changed: {:?} -> {hash}", current_commit);
+                                            current_commit = Some(hash);
+                                        }
+                                        Ok(_) => {
+                                            log::trace!("HEAD unchanged, skipping build");
+                                            pending_build = false;
+                                            continue;
+                                        }
+                                        Err(err) => {
+                                            log::error!("failed to read git HEAD: {err}");
+                                            pending_build = false;
+                                            continue;
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary

Add `--commit` flag to `Watch` that monitors git directory and restarts
command when active commit (HEAD) changes.

Closes #35

## Implementation

- Resolve git dir via `git rev-parse --git-dir` — handles worktrees and
  submodules transparently
- Watch resolved git dir through existing `notify` watcher alongside any
  user-specified paths
- Classify events as git vs file changes in `WatchEventHandler`; only
  re-check HEAD on debounce timeout when all pending changes are git-internal
- Defer `git rev-parse HEAD` to after debounce period — avoids redundant
  git calls on intermediate ref writes

## Behavioral changes

- `is_hidden_path` no longer filters paths under explicitly-watched hidden
  directories (e.g. `--commit` adds `.git/` to watch paths)
- `Event::ChangeDetected` now carries a `git: bool` discriminant so the
  event loop can distinguish git-internal changes from file changes