### PR TITLE
feat!: bypass default commands when --exec/--shell are provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `Watch::run` now uses only the commands from `--exec` or `--shell`
+  when provided, ignoring the `commands` argument entirely. Previously, both the
+  `commands` argument and CLI flags were combined into a single command list. (#37)
+
+### Added
+
+- `FromIterator<Command>` for `CommandList`. (#37)
+
 ## [0.3.5] - 2026-06-02
 
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,34 +173,30 @@ impl Watch {
     /// configured [`debounce`](Self::debounce) duration.
     ///
     /// Workspace's `target` directory and hidden paths are excluded by default.
+    ///
+    /// If `--exec` or `--shell` flags are provided, the `commands` argument is ignored
+    /// and only the commands supplied from them are run.
     pub fn run(mut self, commands: impl Into<CommandList>) -> Result<()> {
         let metadata = metadata();
-        let list = commands.into();
 
-        {
-            let mut commands = list
-                .commands
-                .lock()
-                .expect("no panic-prone code runs while this lock is held");
-
-            commands.extend(self.shell_commands.iter().map(|x| {
-                let mut command =
-                    Command::new(env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string()));
-                command.arg("-c");
-                command.arg(x);
-
-                command
-            }));
-
-            commands.extend(self.cargo_commands.iter().map(|x| {
-                let mut command =
-                    Command::new(env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string()));
-                command.arg("-c");
-                command.arg(format!("cargo {x}"));
-
-                command
-            }));
-        }
+        let list = if self.cargo_commands.is_empty() && self.shell_commands.is_empty() {
+            commands.into()
+        } else {
+            let shell = env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+            self.shell_commands
+                .iter()
+                .map(|x| {
+                    let mut cmd = Command::new(&shell);
+                    cmd.args(["-c", x]);
+                    cmd
+                })
+                .chain(self.cargo_commands.iter().map(|x| {
+                    let mut cmd = Command::new(&shell);
+                    cmd.args(["-c", format!("cargo {x}").as_ref()]);
+                    cmd
+                }))
+                .collect::<CommandList>()
+        };
 
         self.prepare_excludes()?;
 
@@ -553,30 +549,6 @@ pub struct CommandList {
     commands: Arc<Mutex<Vec<Command>>>,
 }
 
-impl From<Command> for CommandList {
-    fn from(command: Command) -> Self {
-        Self {
-            commands: Arc::new(Mutex::new(vec![command])),
-        }
-    }
-}
-
-impl From<Vec<Command>> for CommandList {
-    fn from(commands: Vec<Command>) -> Self {
-        Self {
-            commands: Arc::new(Mutex::new(commands)),
-        }
-    }
-}
-
-impl<const SIZE: usize> From<[Command; SIZE]> for CommandList {
-    fn from(commands: [Command; SIZE]) -> Self {
-        Self {
-            commands: Arc::new(Mutex::new(Vec::from(commands))),
-        }
-    }
-}
-
 impl CommandList {
     /// Returns `true` if the list is empty.
     pub fn is_empty(&self) -> bool {
@@ -617,6 +589,38 @@ impl CommandList {
             }
         }
         Ok(Default::default())
+    }
+}
+
+impl From<Command> for CommandList {
+    fn from(command: Command) -> Self {
+        Self {
+            commands: Arc::new(Mutex::new(vec![command])),
+        }
+    }
+}
+
+impl From<Vec<Command>> for CommandList {
+    fn from(commands: Vec<Command>) -> Self {
+        Self {
+            commands: Arc::new(Mutex::new(commands)),
+        }
+    }
+}
+
+impl<const SIZE: usize> From<[Command; SIZE]> for CommandList {
+    fn from(commands: [Command; SIZE]) -> Self {
+        Self {
+            commands: Arc::new(Mutex::new(Vec::from(commands))),
+        }
+    }
+}
+
+impl FromIterator<Command> for CommandList {
+    fn from_iter<T: IntoIterator<Item = Command>>(iter: T) -> Self {
+        Self {
+            commands: Arc::new(Mutex::new(iter.into_iter().collect())),
+        }
     }
 }
 


### PR DESCRIPTION
The `commands` argument to `Watch::run` is now ignored when `--exec` or `--shell` CLI flags are supplied. Only the commands from those flags are run.

Previously, both the programmatic `commands` argument and CLI flags were merged into a single command list, which could lead to unexpected combinations.

Add `FromIterator<Command>` for `CommandList` to support collecting iterators of commands.

BREAKING CHANGE: `Watch::run` no longer merges the `commands` argument with CLI-provided commands.